### PR TITLE
Groundwork for appointment notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+    testImplementation "org.mockito:mockito-core:3.+"
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -45,6 +45,9 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
+        builder.append("; Notes: ");
+        person.getNotes().forEach(builder::append);
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,7 +26,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Edits the details of an existing person in the address book.
@@ -101,7 +101,7 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, personToEdit.getNotes());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -36,17 +36,17 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+        + "by the index number used in the displayed person list. "
+        + "Existing values will be overwritten by the input values.\n"
+        + "Parameters: INDEX (must be a positive integer) "
+        + "[" + PREFIX_NAME + "NAME] "
+        + "[" + PREFIX_PHONE + "PHONE] "
+        + "[" + PREFIX_EMAIL + "EMAIL] "
+        + "[" + PREFIX_ADDRESS + "ADDRESS] "
+        + "[" + PREFIX_TAG + "TAG]...\n"
+        + "Example: " + COMMAND_WORD + " 1 "
+        + PREFIX_PHONE + "91234567 "
+        + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -56,7 +56,7 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
@@ -101,7 +101,8 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, personToEdit.getNotes());
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
+            personToEdit.getNotes());
     }
 
     @Override
@@ -117,15 +118,15 @@ public class EditCommand extends Command {
 
         EditCommand otherEditCommand = (EditCommand) other;
         return index.equals(otherEditCommand.index)
-                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
+            && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("index", index)
-                .add("editPersonDescriptor", editPersonDescriptor)
-                .toString();
+            .add("index", index)
+            .add("editPersonDescriptor", editPersonDescriptor)
+            .toString();
     }
 
     /**
@@ -139,7 +140,8 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        public EditPersonDescriptor() {}
+        public EditPersonDescriptor() {
+        }
 
         /**
          * Copy constructor.
@@ -222,21 +224,21 @@ public class EditCommand extends Command {
 
             EditPersonDescriptor otherEditPersonDescriptor = (EditPersonDescriptor) other;
             return Objects.equals(name, otherEditPersonDescriptor.name)
-                    && Objects.equals(phone, otherEditPersonDescriptor.phone)
-                    && Objects.equals(email, otherEditPersonDescriptor.email)
-                    && Objects.equals(address, otherEditPersonDescriptor.address)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                && Objects.equals(phone, otherEditPersonDescriptor.phone)
+                && Objects.equals(email, otherEditPersonDescriptor.email)
+                && Objects.equals(address, otherEditPersonDescriptor.address)
+                && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
-                    .add("name", name)
-                    .add("phone", phone)
-                    .add("email", email)
-                    .add("address", address)
-                    .add("tags", tags)
-                    .toString();
+                .add("name", name)
+                .add("phone", phone)
+                .add("email", email)
+                .add("address", address)
+                .add("tags", tags)
+                .toString();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import javafx.collections.FXCollections;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
@@ -17,7 +18,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -45,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, tagList, FXCollections.observableArrayList());
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -17,7 +17,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditCommand object

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -40,7 +40,7 @@ public class ModelManager implements Model {
         this(new AddressBook(), new UserPrefs());
     }
 
-    //=========== UserPrefs ==================================================================================
+    // UserPrefs
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -75,7 +75,7 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookFilePath(addressBookFilePath);
     }
 
-    //=========== AddressBook ================================================================================
+    // AddressBook
 
     @Override
     public void setAddressBook(ReadOnlyAddressBook addressBook) {
@@ -111,7 +111,7 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
-    //=========== Filtered Person List Accessors =============================================================
+    // Filtered Person List Accessors
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -141,8 +141,8 @@ public class ModelManager implements Model {
 
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
-                && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+            && userPrefs.equals(otherModelManager.userPrefs)
+            && filteredPersons.equals(otherModelManager.filteredPersons);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -85,7 +85,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+            && otherPerson.getName().equals(getName());
     }
 
     /**
@@ -105,11 +105,11 @@ public class Person {
 
         Person otherPerson = (Person) other;
         return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags)
-                && notes.equals(otherPerson.notes);
+            && phone.equals(otherPerson.phone)
+            && email.equals(otherPerson.email)
+            && address.equals(otherPerson.address)
+            && tags.equals(otherPerson.tags)
+            && notes.equals(otherPerson.notes);
     }
 
     @Override
@@ -121,15 +121,18 @@ public class Person {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("name", name)
-                .add("phone", phone)
-                .add("email", email)
-                .add("address", address)
-                .add("tags", tags)
-                .add("notes", notes)
-                .toString();
+            .add("name", name)
+            .add("phone", phone)
+            .add("email", email)
+            .add("address", address)
+            .add("tags", tags)
+            .add("notes", notes)
+            .toString();
     }
 
+    /**
+     * Represents a builder for a {@link Person}.
+     */
     public static class Builder {
         private Name name;
         private Phone phone;
@@ -138,7 +141,11 @@ public class Person {
         private Set<Tag> tags = new HashSet<>();
         private ObservableList<Note> notes = FXCollections.observableArrayList();
 
-        public Builder(Name name, Phone phone, Email email, Address address, Set<Tag> tags, ObservableList<Note> notes) {
+        /**
+         * Creates a {@code Builder} with the given parameters.
+         */
+        public Builder(Name name, Phone phone, Email email, Address address, Set<Tag> tags,
+                       ObservableList<Note> notes) {
             this.name = name;
             this.phone = phone;
             this.email = email;
@@ -147,8 +154,12 @@ public class Person {
             this.notes.addAll(notes);
         }
 
+        /**
+         * Initializes the {@code Builder} with the data of {@code person}.
+         */
         public Builder(Person person) {
-            this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(), person.getTags(), person.getNotes());
+            this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(), person.getTags(),
+                person.getNotes());
         }
 
         public Name getName() {
@@ -217,6 +228,9 @@ public class Person {
             return this;
         }
 
+        /**
+         * Builds a {@link Person} with the latest values.
+         */
         public Person build() {
             return new Person(name, phone, email, address, tags, notes);
         }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
@@ -7,8 +8,11 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.note.Note;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Represents a Person in the address book.
@@ -24,17 +28,19 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final ObservableList<Note> notes = FXCollections.observableArrayList();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, ObservableList<Note> notes) {
+        requireAllNonNull(name, phone, email, address, tags, notes);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.notes.addAll(notes);
     }
 
     public Name getName() {
@@ -59,6 +65,14 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an immutable notes list, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public ObservableList<Note> getNotes() {
+        return FXCollections.unmodifiableObservableList(notes);
     }
 
     /**
@@ -94,13 +108,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && notes.equals(otherPerson.notes);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, notes);
     }
 
     @Override
@@ -111,7 +126,99 @@ public class Person {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("notes", notes)
                 .toString();
     }
 
+    public static class Builder {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Set<Tag> tags = new HashSet<>();
+        private ObservableList<Note> notes = FXCollections.observableArrayList();
+
+        public Builder(Name name, Phone phone, Email email, Address address, Set<Tag> tags, ObservableList<Note> notes) {
+            this.name = name;
+            this.phone = phone;
+            this.email = email;
+            this.address = address;
+            this.tags.addAll(tags);
+            this.notes.addAll(notes);
+        }
+
+        public Builder(Person person) {
+            this(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(), person.getTags(), person.getNotes());
+        }
+
+        public Name getName() {
+            return name;
+        }
+
+        public Phone getPhone() {
+            return phone;
+        }
+
+        public Email getEmail() {
+            return email;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+
+        public Set<Tag> getTags() {
+            return tags;
+        }
+
+        public ObservableList<Note> getNotes() {
+            return notes;
+        }
+
+        public Builder setName(Name name) {
+            requireNonNull(name);
+
+            this.name = name;
+            return this;
+        }
+
+        public Builder setPhone(Phone phone) {
+            requireNonNull(phone);
+
+            this.phone = phone;
+            return this;
+        }
+
+        public Builder setEmail(Email email) {
+            requireNonNull(email);
+
+            this.email = email;
+            return this;
+        }
+
+        public Builder setAddress(Address address) {
+            requireNonNull(address);
+
+            this.address = address;
+            return this;
+        }
+
+        public Builder setTags(Set<Tag> tags) {
+            requireNonNull(tags);
+
+            this.tags.addAll(tags);
+            return this;
+        }
+
+        public Builder setNotes(ObservableList<Note> notes) {
+            requireNonNull(notes);
+
+            this.notes.addAll(notes);
+            return this;
+        }
+
+        public Person build() {
+            return new Person(name, phone, email, address, tags, notes);
+        }
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -114,7 +114,6 @@ public class Person {
 
     @Override
     public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(name, phone, email, address, tags, notes);
     }
 
@@ -217,6 +216,7 @@ public class Person {
         public Builder setTags(Set<Tag> tags) {
             requireNonNull(tags);
 
+            this.tags.clear();
             this.tags.addAll(tags);
             return this;
         }
@@ -224,6 +224,7 @@ public class Person {
         public Builder setNotes(ObservableList<Note> notes) {
             requireNonNull(notes);
 
+            this.notes.clear();
             this.notes.addAll(notes);
             return this;
         }

--- a/src/main/java/seedu/address/model/person/note/Description.java
+++ b/src/main/java/seedu/address/model/person/note/Description.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person.note;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class Description {
+    public static final String MESSAGE_CONSTRAINTS = "Note should not be blank";
+
+    public final String description;
+
+    public Description(String description) {
+        requireNonNull(description);
+        checkArgument(isValid(description), MESSAGE_CONSTRAINTS);
+        this.description = description;
+    }
+
+    public static boolean isValid(String test) {
+        return !test.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Description that = (Description) o;
+
+        return Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return description != null ? description.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/src/main/java/seedu/address/model/person/note/Description.java
+++ b/src/main/java/seedu/address/model/person/note/Description.java
@@ -33,6 +33,7 @@ public class Description {
         if (this == o) {
             return true;
         }
+
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
@@ -44,7 +45,7 @@ public class Description {
 
     @Override
     public int hashCode() {
-        return description != null ? description.hashCode() : 0;
+        return Objects.hash(description);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/note/Description.java
+++ b/src/main/java/seedu/address/model/person/note/Description.java
@@ -1,15 +1,23 @@
 package seedu.address.model.person.note;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
+/**
+ * Represents a Note's description.
+ */
 public class Description {
     public static final String MESSAGE_CONSTRAINTS = "Note should not be blank";
 
     public final String description;
 
+    /**
+     * Constructs a {@code Description}.
+     *
+     * @param description A valid description.
+     */
     public Description(String description) {
         requireNonNull(description);
         checkArgument(isValid(description), MESSAGE_CONSTRAINTS);
@@ -22,8 +30,12 @@ public class Description {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Description that = (Description) o;
 

--- a/src/main/java/seedu/address/model/person/note/Note.java
+++ b/src/main/java/seedu/address/model/person/note/Note.java
@@ -1,0 +1,54 @@
+package seedu.address.model.person.note;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+public class Note {
+    private final LocalDateTime dateTime;
+    private final Description description;
+
+    public Note(LocalDateTime dateTime, Description description) {
+        requireAllNonNull(dateTime, description);
+
+        this.dateTime = dateTime;
+        this.description = description;
+    }
+
+    public LocalDateTime getDateTime() {
+        return dateTime;
+    }
+
+    public Description getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Note note = (Note) o;
+
+        if (!Objects.equals(dateTime, note.dateTime)) return false;
+        return Objects.equals(description, note.description);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = dateTime != null ? dateTime.hashCode() : 0;
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("dateTime", dateTime)
+                .add("description", description)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/note/Note.java
+++ b/src/main/java/seedu/address/model/person/note/Note.java
@@ -40,6 +40,7 @@ public class Note {
         if (this == o) {
             return true;
         }
+
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
@@ -49,14 +50,13 @@ public class Note {
         if (!Objects.equals(dateTime, note.dateTime)) {
             return false;
         }
+
         return Objects.equals(description, note.description);
     }
 
     @Override
     public int hashCode() {
-        int result = dateTime != null ? dateTime.hashCode() : 0;
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        return result;
+        return Objects.hash(dateTime, description);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/note/Note.java
+++ b/src/main/java/seedu/address/model/person/note/Note.java
@@ -1,16 +1,25 @@
 package seedu.address.model.person.note;
 
-import seedu.address.commons.util.ToStringBuilder;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import seedu.address.commons.util.ToStringBuilder;
 
+/**
+ * Represents an Appointment Note.
+ */
 public class Note {
     private final LocalDateTime dateTime;
     private final Description description;
 
+    /**
+     * Constructs a {@code Note}.
+     *
+     * @param dateTime A date and time.
+     * @param description A valid description.
+     */
     public Note(LocalDateTime dateTime, Description description) {
         requireAllNonNull(dateTime, description);
 
@@ -28,12 +37,18 @@ public class Note {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Note note = (Note) o;
 
-        if (!Objects.equals(dateTime, note.dateTime)) return false;
+        if (!Objects.equals(dateTime, note.dateTime)) {
+            return false;
+        }
         return Objects.equals(description, note.description);
     }
 

--- a/src/main/java/seedu/address/model/person/note/exceptions/NoteNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/note/exceptions/NoteNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.person.note.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified note.
+ */
+public class NoteNotFoundException extends RuntimeException { }

--- a/src/main/java/seedu/address/model/person/tag/Tag.java
+++ b/src/main/java/seedu/address/model/person/tag/Tag.java
@@ -1,4 +1,4 @@
-package seedu.address.model.tag;
+package seedu.address.model.person.tag;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,9 +1,13 @@
 package seedu.address.model.util;
 
+import static javafx.collections.FXCollections.observableList;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
@@ -11,32 +15,58 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
-        return new Person[] {
+        return new Person[]{
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                getTags("friends"), getNotes(
+                    new Note[]{
+                        new Note(LocalDateTime.of(2024, 2, 19, 21, 30), new Description("General Flu")),
+                        new Note(LocalDateTime.of(2024, 2, 28, 8, 30), new Description("Headache")),
+                    })),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                getTags("colleagues", "friends"), getNotes(
+                    new Note[]{
+                        new Note(LocalDateTime.of(2024, 1, 2, 10, 0), new Description("Annual physical exam")),
+                        new Note(LocalDateTime.of(2024, 3, 15, 9, 15), new Description("Follow-up for blood pressure")),
+                        new Note(LocalDateTime.of(2024, 6, 7, 15, 0), new Description("Dermatology consultation"))
+                    })),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                getTags("neighbours"), getNotes(
+                    new Note[]{
+                        new Note(LocalDateTime.of(2023, 2, 10, 14, 0), new Description("Vision checkup")),
+                        new Note(LocalDateTime.of(2023, 5, 23, 9, 0), new Description("Stomach pain evaluation")),
+                        new Note(LocalDateTime.of(2024, 6, 6, 11, 15), new Description("Prenatal checkup")),
+                    })),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                getTags("family"), getNotes(
+                    new Note[]{
+                        new Note(LocalDateTime.of(2024, 2, 20, 15, 30), new Description("Joint pain assessment")),
+                        new Note(LocalDateTime.of(2024, 4, 4, 10, 30), new Description("Post-surgery checkup")),
+                        new Note(LocalDateTime.of(2024, 5, 19, 17, 0), new Description("Sports injury follow-up")),
+                    })),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                getTags("classmates"), getNotes(new Note[]{})),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                getTags("colleagues"), getNotes(
+                    new Note[]{
+                        new Note(LocalDateTime.of(2023, 8, 16, 14, 45), new Description("Mental health consultation")),
+                        new Note(LocalDateTime.of(2024, 1, 28, 10, 15), new Description("Blood sugar monitoring review")),
+                        new Note(LocalDateTime.of(2024, 4, 5, 16, 0), new Description("Sore throat and fever")),
+                    }))
         };
     }
 
@@ -51,10 +81,18 @@ public class SampleDataUtil {
     /**
      * Returns a tag set containing the list of strings given.
      */
-    public static Set<Tag> getTagSet(String... strings) {
+    public static Set<Tag> getTags(String... strings) {
         return Arrays.stream(strings)
-                .map(Tag::new)
-                .collect(Collectors.toSet());
+            .map(Tag::new)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a note list containing the list of notes given.
+     */
+    public static ObservableList<Note> getNotes(Note[] notes) {
+        return Arrays.stream(notes)
+            .collect(Collectors.toCollection(FXCollections::observableArrayList));
     }
 
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,6 +1,5 @@
 package seedu.address.model.util;
 
-import static javafx.collections.FXCollections.observableList;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
@@ -64,7 +63,7 @@ public class SampleDataUtil {
                 getTags("colleagues"), getNotes(
                     new Note[]{
                         new Note(LocalDateTime.of(2023, 8, 16, 14, 45), new Description("Mental health consultation")),
-                        new Note(LocalDateTime.of(2024, 1, 28, 10, 15), new Description("Blood sugar monitoring review")),
+                        new Note(LocalDateTime.of(2024, 1, 28, 10, 15), new Description("Blood sugar review")),
                         new Note(LocalDateTime.of(2024, 4, 5, 16, 0), new Description("Sore throat and fever")),
                     }))
         };

--- a/src/main/java/seedu/address/storage/JsonAdapatedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdapatedNote.java
@@ -1,9 +1,10 @@
 package seedu.address.storage;
 
 import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.note.Description;

--- a/src/main/java/seedu/address/storage/JsonAdapatedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdapatedNote.java
@@ -1,0 +1,55 @@
+package seedu.address.storage;
+
+import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
+
+/**
+ * Jackson-friendly version of {@link Note}.
+ */
+public class JsonAdapatedNote {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Note's %s field is missing!";
+    private final LocalDateTime dateTime;
+    private final String description;
+
+    /**
+     * Constructs a {@code JsonAdapatedNote} with the given parameters.
+     */
+    @JsonCreator
+    public JsonAdapatedNote(@JsonProperty("dateTime") LocalDateTime dateTime,
+                            @JsonProperty("description") String description) {
+        this.dateTime = dateTime;
+        this.description = description;
+    }
+
+    /**
+     * Converts a given {@code Note} into this class for Jackson use.
+     */
+    public JsonAdapatedNote(Note source) {
+        this.dateTime = source.getDateTime();
+        this.description = source.getDescription().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Note} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public Note toModelType() throws IllegalValueException {
+        if (this.description == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Description.isValid(this.description)) {
+            throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
+        }
+        final Description description = new Description(this.description);
+
+        return new Note(dateTime, description);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdapatedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdapatedNote.java
@@ -45,9 +45,11 @@ public class JsonAdapatedNote {
         if (this.description == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
+
         if (!Description.isValid(this.description)) {
             throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
         }
+
         final Description description = new Description(this.description);
 
         return new Note(dateTime, description);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -9,13 +9,16 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.note.Note;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Person}.
@@ -29,20 +32,25 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final List<JsonAdapatedNote> notes = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                             @JsonProperty("notes") List<JsonAdapatedNote> notes) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         if (tags != null) {
             this.tags.addAll(tags);
+        }
+        if (notes != null) {
+            this.notes.addAll(notes);
         }
     }
 
@@ -55,8 +63,11 @@ class JsonAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         tags.addAll(source.getTags().stream()
-                .map(JsonAdaptedTag::new)
-                .collect(Collectors.toList()));
+            .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList()));
+        notes.addAll(source.getNotes().stream()
+            .map(JsonAdapatedNote::new)
+            .collect(Collectors.toList()));
     }
 
     /**
@@ -65,9 +76,14 @@ class JsonAdaptedPerson {
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
     public Person toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tags) {
-            personTags.add(tag.toModelType());
+        final List<Tag> tags = new ArrayList<>();
+        for (JsonAdaptedTag tag : this.tags) {
+            tags.add(tag.toModelType());
+        }
+
+        final ObservableList<Note> notes = FXCollections.observableArrayList();
+        for (JsonAdapatedNote note : this.notes) {
+            notes.add(note.toModelType());
         }
 
         if (name == null) {
@@ -102,8 +118,8 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
-        final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        final Set<Tag> modelTags = new HashSet<>(tags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, notes);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Tag}.

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,64 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "notes" : [ {
+      "dateTime" : "2024-02-19T21:30:00",
+      "description" : "General Flu"
+    }, {
+      "dateTime" : "2024-02-28T08:30:00",
+      "description" : "Headache"
+    } ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
+    "tags" : [ "owesMoney", "friends" ],
+    "notes" : [ {
+      "dateTime" : "2024-02-20T15:30:00",
+      "description" : "Joint pain assessment"
+    }, {
+      "dateTime" : "2024-04-04T10:30:00",
+      "description" : "Post-surgery checkup"
+    }, {
+      "dateTime" : "2024-05-19T17:00:00",
+      "description" : "Sports injury follow-up"
+    } ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "notes" : [ ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "notes" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +20,8 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -36,6 +39,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final Note VALID_NOTE_FLU = new Note(LocalDateTime.of(2024, 2, 19, 21, 30), new Description("General Flu"));
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -39,7 +39,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
-    public static final Note VALID_NOTE_FLU = new Note(LocalDateTime.of(2024, 2, 19, 21, 30), new Description("General Flu"));
+    public static final Note VALID_NOTE_FLU =
+        new Note(LocalDateTime.of(2024, 2, 19, 21, 30), new Description("General Flu"));
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -66,11 +67,11 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+            .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**
@@ -79,7 +80,7 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -94,7 +95,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
+                                            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -115,6 +116,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.note.Note;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
@@ -37,7 +38,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Person editedPerson = new PersonBuilder().build();
+        PersonBuilder builder = new PersonBuilder();
+        // We must include notes, as notes can't be modified by the edit command.
+        builder.withNotes(model.getFilteredPersonList().get(0).getNotes().toArray(new Note[0]));
+
+        Person editedPerson = builder.build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -61,11 +61,12 @@ public class EditPersonDescriptorTest {
     public void toStringMethod() {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
-                + editPersonDescriptor.getName().orElse(null) + ", phone="
-                + editPersonDescriptor.getPhone().orElse(null) + ", email="
-                + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + "}";
+            + editPersonDescriptor.getName().orElse(null) + ", phone="
+            + editPersonDescriptor.getPhone().orElse(null) + ", email="
+            + editPersonDescriptor.getEmail().orElse(null) + ", address="
+            + editPersonDescriptor.getAddress().orElse(null) + ", tags="
+            + editPersonDescriptor.getTags().orElse(null) + "}";
+
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -42,7 +42,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -42,7 +42,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 public class EditCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -99,8 +99,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-            + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() +
-            ", notes=" + ALICE.getNotes() + "}";
+            + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
+            + ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_FLU;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -14,6 +15,7 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.note.Note;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
@@ -34,7 +36,7 @@ public class PersonTest {
 
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -88,12 +90,17 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // different notes -> returns false
+        editedAlice = new PersonBuilder(ALICE).withNotes(new Note[] {VALID_NOTE_FLU}).build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+            + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() +
+            ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
@@ -11,8 +12,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.note.Note;
@@ -57,43 +60,43 @@ public class PersonTest {
     public void equals() {
         // same values -> returns true
         Person aliceCopy = new PersonBuilder(ALICE).build();
-        assertTrue(ALICE.equals(aliceCopy));
+        assertEquals(ALICE, aliceCopy);
 
         // same object -> returns true
-        assertTrue(ALICE.equals(ALICE));
+        assertEquals(ALICE, ALICE);
 
         // null -> returns false
-        assertFalse(ALICE.equals(null));
+        assertNotEquals(null, ALICE);
 
         // different type -> returns false
-        assertFalse(ALICE.equals(5));
+        assertNotEquals(5, ALICE);
 
         // different person -> returns false
-        assertFalse(ALICE.equals(BOB));
+        assertNotEquals(ALICE, BOB);
 
         // different name -> returns false
         Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different phone -> returns false
         editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different email -> returns false
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different address -> returns false
         editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
 
         // different notes -> returns false
         editedAlice = new PersonBuilder(ALICE).withNotes(new Note[] {VALID_NOTE_FLU}).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertNotEquals(ALICE, editedAlice);
     }
 
     @Test
@@ -102,5 +105,27 @@ public class PersonTest {
             + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
             + ", notes=" + ALICE.getNotes() + "}";
         assertEquals(expected, ALICE.toString());
+    }
+
+    @Nested
+    class BuilderTests {
+        @Test
+        public void build_default_returnsPerson() {
+            var builder = new Person.Builder(ALICE);
+            assertEquals(ALICE, builder.build());
+        }
+
+        @Test
+        public void build_updateValues_returnsPerson() {
+            var builder = new Person.Builder(ALICE)
+                .setName(BENSON.getName())
+                .setPhone(BENSON.getPhone())
+                .setEmail(BENSON.getEmail())
+                .setAddress(BENSON.getAddress())
+                .setTags(BENSON.getTags())
+                .setNotes(BENSON.getNotes());
+
+            assertEquals(BENSON, builder.build());
+        }
     }
 }

--- a/src/test/java/seedu/address/model/person/note/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/person/note/DescriptionTest.java
@@ -1,6 +1,8 @@
 package seedu.address.model.person.note;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -37,6 +39,64 @@ public class DescriptionTest {
         @Test
         public void isValid_valid() {
             assertTrue(Description.isValid("Blk 456, Den Road, #01-355"));
+        }
+    }
+
+    @Nested
+    class EqualsTests {
+        @Test
+        public void equals_sameValues() {
+            Description description1 = new Description("Test");
+            Description description2 = new Description("Test");
+            assertEquals(description1, description2);
+        }
+
+        @Test
+        public void equals_differentValues() {
+            Description description1 = new Description("Test1");
+            Description description2 = new Description("Test2");
+            assertNotEquals(description1, description2);
+        }
+
+        @Test
+        public void equals_null() {
+            Description description = new Description("Test");
+            assertNotEquals(description, null);
+        }
+
+        @Test
+        public void equals_differentClass() {
+            Description description = new Description("Test");
+            Object other = new Object();
+            assertNotEquals(description, other);
+        }
+    }
+
+    @Nested
+    class HashCodeTests {
+        @Test
+        public void hashCode_same() {
+            Description description1 = new Description("Test");
+            Description description2 = new Description("Test");
+            assertEquals(description1.hashCode(), description2.hashCode());
+        }
+
+        @Test
+        public void hashCode_different() {
+            Description description1 = new Description("Test1");
+            Description description2 = new Description("Test2");
+
+            assertNotEquals(description1.hashCode(), description2.hashCode());
+        }
+    }
+
+    @Nested
+    class ToStringTests {
+        @Test
+        public void toString_sucess() {
+            String validDescription = "Some valid description";
+            Description description = new Description(validDescription);
+            assertEquals(validDescription, description.toString());
         }
     }
 }

--- a/src/test/java/seedu/address/model/person/note/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/person/note/DescriptionTest.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person.note;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class DescriptionTest {
+    @Nested
+    class ConstructorTests {
+        @Test
+        public void constructor_null_throwsNullPointerException() {
+            assertThrows(NullPointerException.class, () -> new Description(null));
+        }
+
+        @Test
+        public void constructor_invalidAddress_throwsIllegalArgumentException() {
+            String invalid = "";
+            assertThrows(IllegalArgumentException.class, () -> new Description(invalid));
+        }
+    }
+
+    @Nested
+    class IsValidTests {
+        @Test
+        public void isValid_null_throwsNullPointerException() {
+            assertThrows(NullPointerException.class, () -> Description.isValid(null));
+        }
+
+        @Test
+        public void isValid_invalid() {
+            assertFalse(Description.isValid(""));
+        }
+
+        @Test
+        public void isValid_valid() {
+            assertTrue(Description.isValid("Blk 456, Den Road, #01-355"));
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/person/note/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/person/note/DescriptionTest.java
@@ -3,6 +3,7 @@ package seedu.address.model.person.note;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/person/note/NoteTest.java
+++ b/src/test/java/seedu/address/model/person/note/NoteTest.java
@@ -1,6 +1,11 @@
 package seedu.address.model.person.note;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,6 +16,80 @@ public class NoteTest {
         @Test
         public void constructor_null_throwsNullPointerException() {
             assertThrows(NullPointerException.class, () -> new Note(null, null));
+        }
+
+        @Test
+        public void constructor_success_createsInstance() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            Description description = new Description("Some description");
+            Note note = new Note(dateTime, description);
+            assertNotNull(note);
+            assertEquals(dateTime, note.getDateTime());
+            assertEquals(description, note.getDescription());
+        }
+    }
+
+    @Nested
+    class EqualsTests {
+        @Test
+        public void equals_same() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            Description description = new Description("Test description");
+            Note note1 = new Note(dateTime, description);
+            Note note2 = new Note(dateTime, description);
+            assertEquals(note1, note2);
+        }
+
+        @Test
+        public void equals_differentDateTime() {
+            Description description = new Description("Test description");
+            Note note1 = new Note(LocalDateTime.now(), description);
+            Note note2 = new Note(LocalDateTime.now().plusDays(1), description);
+            assertNotEquals(note1, note2);
+        }
+
+        @Test
+        public void equals_differentDescription() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            Note note1 = new Note(dateTime, new Description("Description 1"));
+            Note note2 = new Note(dateTime, new Description("Description 2"));
+            assertNotEquals(note1, note2);
+        }
+    }
+
+    @Nested
+    class HashCodeTests {
+        @Test
+        public void hashCode_same() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            Description description = new Description("Test description");
+            Note note1 = new Note(dateTime, description);
+            Note note2 = new Note(dateTime, description);
+            assertEquals(note1.hashCode(), note2.hashCode());
+        }
+
+        @Test
+        public void hashCode_different() {
+            LocalDateTime dateTime = LocalDateTime.now();
+            Description description = new Description("Test description");
+            Note note1 = new Note(dateTime, description);
+            Note note2 = new Note(dateTime, description);
+            assertEquals(note1.hashCode(), note2.hashCode());
+        }
+    }
+
+    @Nested
+    class ToStringTests {
+        @Test
+        public void toString_success() {
+            LocalDateTime dateTime = LocalDateTime.of(2023, 4, 20, 15, 30);
+            Description description = new Description("Appointment at clinic");
+            Note note = new Note(dateTime, description);
+            String expected =
+                String.format("seedu.address.model.person.note.Note{dateTime=%s, description=%s}", dateTime,
+                    description);
+
+            assertEquals(expected, note.toString());
         }
     }
 }

--- a/src/test/java/seedu/address/model/person/note/NoteTest.java
+++ b/src/test/java/seedu/address/model/person/note/NoteTest.java
@@ -1,0 +1,15 @@
+package seedu.address.model.person.note;
+
+import static seedu.address.testutil.Assert.assertThrows;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class NoteTest {
+    @Nested
+    class ConstructorTests {
+        @Test
+        public void constructor_null_throwsNullPointerException() {
+            assertThrows(NullPointerException.class, () -> new Note(null, null));
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/person/note/NoteTest.java
+++ b/src/test/java/seedu/address/model/person/note/NoteTest.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person.note;
 
 import static seedu.address.testutil.Assert.assertThrows;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/person/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/person/tag/TagTest.java
@@ -1,8 +1,9 @@
-package seedu.address.model.tag;
+package seedu.address.model.person.tag;
 
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import seedu.address.model.person.tag.Tag;
 
 public class TagTest {
 

--- a/src/test/java/seedu/address/model/person/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/person/tag/TagTest.java
@@ -3,7 +3,6 @@ package seedu.address.model.person.tag;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import seedu.address.model.person.tag.Tag;
 
 public class TagTest {
 

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -1,0 +1,75 @@
+package seedu.address.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
+import seedu.address.model.person.tag.Tag;
+
+public class SampleDataUtilTest {
+    private static final LocalDateTime TEST_DATE_TIME = LocalDateTime.of(2024, 1, 1, 12, 30);
+
+    @Nested
+    class GetSampleAddressBookTests {
+        @Test
+        public void getSampleAddressBook_success_returnsAddressBook() {
+            ReadOnlyAddressBook result = SampleDataUtil.getSampleAddressBook();
+            assertNotNull(result);
+            assertFalse(result.getPersonList().isEmpty());
+        }
+    }
+
+    @Nested
+    class GetTagsTests {
+        @Test
+        void getTags_success_returnsEmptySet() {
+            Set<Tag> tags = SampleDataUtil.getTags();
+
+            assertTrue(tags.isEmpty());
+        }
+
+        @Test
+        public void getTags_success_returnsPopulatedSet() {
+            String[] tags = {"friend", "colleague"};
+            Set<Tag> result = SampleDataUtil.getTags(tags);
+
+            assertEquals(2, result.size());
+            assertTrue(result.contains(new Tag(tags[0])));
+            assertTrue(result.contains(new Tag(tags[1])));
+        }
+    }
+
+    @Nested
+    class GetNotesTests {
+        @Test
+        public void getNotes_success_returnsEmptyList() {
+            Note[] notes = {};
+            ObservableList<Note> result = SampleDataUtil.getNotes(notes);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        public void getNotes_success_returnsPopulatedList() {
+            var note1 = new Note(TEST_DATE_TIME, new Description("Sample note 1"));
+            var note2 = new Note(TEST_DATE_TIME, new Description("Sample note 2"));
+            Note[] notes = {note1, note2};
+            ObservableList<Note> result = SampleDataUtil.getNotes(notes);
+
+            assertEquals(2, result.size());
+            assertEquals(note1, result.get(0));
+            assertEquals(note2, result.get(1));
+        }
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdapatedNoteTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdapatedNoteTest.java
@@ -1,0 +1,67 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
+
+public class JsonAdapatedNoteTest {
+
+    private static final LocalDateTime TEST_DATE_TIME = LocalDateTime.of(2024, 1, 1, 12, 30);
+    private static final String VALID_DESCRIPTION = "General Flu";
+    private static final String INVALID_DESCRIPTION = "";
+
+    @Nested
+    class ConstructorTests {
+        @Test
+        public void constructor_jsonProperty_returnsNote() {
+            JsonAdapatedNote jsonAdapatedNote = new JsonAdapatedNote(TEST_DATE_TIME, VALID_DESCRIPTION);
+
+            assertNotNull(jsonAdapatedNote);
+        }
+
+        @Test
+        public void constructor_note_returnsNote() {
+            JsonAdapatedNote jsonAdapatedNote =
+                new JsonAdapatedNote(new Note(TEST_DATE_TIME, new Description(VALID_DESCRIPTION)));
+
+            assertNotNull(jsonAdapatedNote);
+        }
+    }
+
+    @Nested
+    class ToModelTypeTests {
+
+        @Test
+        public void toModelType_success_returnsNote() throws Exception {
+            Note original = new Note(TEST_DATE_TIME, new Description(VALID_DESCRIPTION));
+            JsonAdapatedNote jsonAdapatedNote = new JsonAdapatedNote(original);
+            Note modelNote = jsonAdapatedNote.toModelType();
+
+            assertEquals(original, modelNote);
+        }
+
+        @Test
+        public void toModelType_invalidDescription_throwsIllegalValueException() {
+            JsonAdapatedNote jsonAdapatedNote = new JsonAdapatedNote(TEST_DATE_TIME, INVALID_DESCRIPTION);
+
+            assertThrows(IllegalValueException.class, jsonAdapatedNote::toModelType);
+        }
+
+        @Test
+        public void toModelType_nullDescription_throwsIllegalValueException() {
+            JsonAdapatedNote jsonAdapatedNote = new JsonAdapatedNote(TEST_DATE_TIME, null);
+
+            assertThrows(IllegalValueException.class, jsonAdapatedNote::toModelType);
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,21 +1,28 @@
 package seedu.address.storage;
 
+import static javafx.collections.FXCollections.observableList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -32,6 +39,10 @@ public class JsonAdaptedPersonTest {
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
 
+    private static final ObservableList<JsonAdapatedNote> VALID_NOTES = BENSON.getNotes().stream()
+        .map(JsonAdapatedNote::new)
+        .collect(Collectors.toCollection(FXCollections::observableArrayList));
+
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(BENSON);
@@ -41,14 +52,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +67,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +82,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +97,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +114,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_NOTES);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,14 +1,11 @@
 package seedu.address.storage;
 
-import static javafx.collections.FXCollections.observableList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,8 +18,6 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.note.Description;
-import seedu.address.model.person.note.Note;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -36,8 +31,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
-            .map(JsonAdaptedTag::new)
-            .collect(Collectors.toList());
+        .map(JsonAdaptedTag::new)
+        .collect(Collectors.toList());
 
     private static final ObservableList<JsonAdapatedNote> VALID_NOTES = BENSON.getNotes().stream()
         .map(JsonAdapatedNote::new)
@@ -52,14 +47,15 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+            new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+        JsonAdaptedPerson person =
+            new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,14 +63,15 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+            new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+        JsonAdaptedPerson person =
+            new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,14 +79,15 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+            new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+        JsonAdaptedPerson person =
+            new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,14 +95,15 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_NOTES);
+            new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_NOTES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_NOTES);
+        JsonAdaptedPerson person =
+            new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_NOTES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -114,7 +113,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_NOTES);
+            new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_NOTES);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -26,6 +26,7 @@ public class JsonSerializableAddressBookTest {
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -10,7 +10,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * A utility class to help with building EditPersonDescriptor objects.

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -3,12 +3,15 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.note.Note;
+import seedu.address.model.person.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
 /**
@@ -25,7 +28,8 @@ public class PersonBuilder {
     private Phone phone;
     private Email email;
     private Address address;
-    private Set<Tag> tags;
+    private Set<Tag> tags = new HashSet<>();
+    private ObservableList<Note> notes = FXCollections.observableArrayList();
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -35,7 +39,6 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
-        tags = new HashSet<>();
     }
 
     /**
@@ -46,7 +49,8 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
-        tags = new HashSet<>(personToCopy.getTags());
+        this.tags.addAll(personToCopy.getTags());
+        this.notes.addAll(personToCopy.getNotes());
     }
 
     /**
@@ -61,7 +65,15 @@ public class PersonBuilder {
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withTags(String ... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
+        this.tags = SampleDataUtil.getTags(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code notes} into a {@code ObservableList<Note>} and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withNotes(Note[] notes) {
+        this.notes = SampleDataUtil.getNotes(notes);
         return this;
     }
 
@@ -90,7 +102,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, notes);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -70,7 +70,8 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code notes} into a {@code ObservableList<Note>} and set it to the {@code Person} that we are building.
+     * Parses the {@code notes} into a {@code ObservableList<Note>} and set it to the {@code Person} that we are
+     * building.
      */
     public PersonBuilder withNotes(Note[] notes) {
         this.notes = SampleDataUtil.getNotes(notes);

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Person;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.person.tag.Tag;
 
 /**
  * A utility class for Person.

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -11,12 +11,15 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.note.Description;
+import seedu.address.model.person.note.Note;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
@@ -24,40 +27,48 @@ import seedu.address.model.person.Person;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
-            .withTags("friends").build();
+        .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+        .withPhone("94351253")
+        .withTags("friends").withNotes(new Note[] {
+            new Note(LocalDateTime.of(2024, 2, 19, 21, 30), new Description("General Flu")),
+            new Note(LocalDateTime.of(2024, 2, 28, 8, 30), new Description("Headache")),
+        }).build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+        .withAddress("311, Clementi Ave 2, #02-25")
+        .withEmail("johnd@example.com").withPhone("98765432")
+        .withTags("owesMoney", "friends").withNotes(new Note[] {
+            new Note(LocalDateTime.of(2024, 2, 20, 15, 30), new Description("Joint pain assessment")),
+            new Note(LocalDateTime.of(2024, 4, 4, 10, 30), new Description("Post-surgery checkup")),
+            new Note(LocalDateTime.of(2024, 5, 19, 17, 0), new Description("Sports injury follow-up")),
+        }).build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+        .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+        .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+        .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+        .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+        .withEmail("anna@example.com").withAddress("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+        .withEmail("stefan@example.com").withAddress("little india").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+        .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+        .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+        .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+        .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
-    private TypicalPersons() {} // prevents instantiation
+    private TypicalPersons() {
+    } // prevents instantiation
 
     /**
      * Returns an {@code AddressBook} with all the typical persons.


### PR DESCRIPTION
This PR implements the groundwork for appointment notes.
- A person object contains a list of notes.
- Currently, the person object is immutable without a good way to make changes. This PR implements the builder pattern to address the issue. The builder can be accessed through `Person.Builder`.
- When updating appointment notes, it is recommended to use the `Person.Builder` class in tandem with the `setPerson()` from `ModelManager`.

**Related to:**
- #12 
- #13 
- #14 
- #15 