### PR TITLE
Minor bug fix for list command predicate reload

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -20,6 +20,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.setFilterPersonsPredicate(PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }


### PR DESCRIPTION
Just a very minor bug fix to ensure that whenever ListCommand is called it will also update the model predicate for the filteredPersonList and not just the FindCommand.